### PR TITLE
Fix ignore types

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -300,9 +300,7 @@ class Configuration
         $params = array_replace_recursive($defaults, $array);
 
         // Ignore Types
-        if (!empty($array['ignoreTypes'])) {
-            $params['ignoreTypes'] = $array['ignoreTypes']; // Overwrite ignored types
-        }
+        $params['ignoreTypes'] = $array['ignoreTypes']; // Overwrite ignored types
 
         // Set Types (overwrite ignored types)
         if (!empty($array['types'])) {


### PR DESCRIPTION
As written in documentation `To allow all types just keep empty types and set empty ignoreTypes `
However the ignoreTypes array required a empty key.

Now you can do:
```
  'types' => [],
  'ignoreTypes' => [],
```

instead of:
```
  'types' => [],
  'ignoreTypes' => [''],
```
To show all types