### PR TITLE
feat: allows generated changelog to have configurable version headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [1.10.7](https://github.com/marcocesarato/php-conventional-changelog/compare/v1.10.6...v1.10.7) (2021-05-15)
+
+
+### Features
+
+* Add option to render text instead of links in generated changelog ([5cb2e5](https://github.com/marcocesarato/php-conventional-changelog/commit/5cb2e5d2d8b9b445e38eede49dbc3a8036ba36a6))
+
+---
+
 ## [1.10.6](https://github.com/marcocesarato/php-conventional-changelog/compare/v1.10.5...v1.10.6) (2021-05-15)
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">PHP Conventional Changelog</h1>
 
-![Version](https://img.shields.io/badge/version-1.10.6-brightgreen?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-1.10.7-brightgreen?style=for-the-badge)
 ![Requirements](https://img.shields.io/badge/php-%3E%3D%207.1.3-4F5D95?style=for-the-badge)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow?style=for-the-badge)](https://conventionalcommits.org)
 ![License](https://img.shields.io/github/license/marcocesarato/php-conventional-changelog?style=for-the-badge)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "marcocesarato/php-conventional-changelog",
     "description": "Generate changelogs and release notes from a project's commit messages and metadata and automate versioning with semver.org and conventionalcommits.org",
-    "version": "1.10.6",
+    "version": "1.10.7",
     "type": "library",
     "license": "GPL-3.0-or-later",
     "minimum-stability": "stable",

--- a/conventional-changelog
+++ b/conventional-changelog
@@ -27,7 +27,7 @@ $command = new DefaultCommand($config);
 $commandName = $command->getName();
 
 // Run application single command
-$application = new Application('conventional-changelog', '1.10.6');
+$application = new Application('conventional-changelog', '1.10.7');
 $application->add($command);
 $application->setDefaultCommand($commandName, true);
 $application->run();

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,7 @@ dir or use the `--config` option to specify the location of your configuration f
 - **Skip Tag:** Skip automatic commit tagging
 - **Skip Verify:** Skip the pre-commit and commit-msg hooks
 - **Disable Links:** Render text instead of link in changelog
+- **Changelog Version Format:** Allows the version header in changelog to have a configurable format
 - **Hidden Hash:** Hide commit hash from changelog
 - **Hidden Mentions:** Hide users mentions from changelog
 - **Hidden References:** Hide issue references from changelog
@@ -84,6 +85,7 @@ return [
   'skipTag' => false,
   'skipVerify' => false,
   'disableLinks' => false,
+  'changelogVersionFormat' => '## {{version}} ({{date}})',
   'hiddenHash' => false,
   'hiddenMentions' => false,
   'hiddenReferences' => false,

--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -351,7 +351,8 @@ class Changelog
             $params['to'] = $this->getVersionCode($params['to'], $tagPrefix, $tagSuffix);
             $compareUrl = $this->getCompareUrl($params['from'], "{$tagPrefix}{$params['to']}{$tagSuffix}");
             $markdownCompareLink = $this->getMarkdownLink($params['to'], $compareUrl);
-            $changelogNew .= "## {$markdownCompareLink} ({$params['date']})\n\n";
+            $changeLogVersionHeading = $this->getChangelogVersionHeading($markdownCompareLink, $params['date']);
+            $changelogNew .= $changeLogVersionHeading;
             // Add all changes list to new changelog
             $changelogNew .= $this->getMarkdownChanges($changes);
         }
@@ -544,6 +545,19 @@ class Changelog
     protected function getMarkdownLink(string $text, string $url): string
     {
         return !$this->config->isDisableLinks() ? "[{$text}]({$url})" : $text;
+    }
+
+    protected function getChangelogVersionHeading($markdownCompareLink, $versionDate)
+    {
+        $versionFormat = $this->config->getChangelogVersionFormat();
+
+        // Handle the replacements.
+        $versionData = $this->getCompiledString($versionFormat, [
+            'version' => $markdownCompareLink,
+            'date' => $versionDate,
+        ]);
+
+        return $versionData;
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -139,6 +139,13 @@ class Configuration
     protected $disableLinks = false;
 
     /**
+     * Allows configurable changelog version header format.
+     *
+     * @var string
+     */
+    protected $changelogVersionFormat = '## {{version}} ({{date}})';
+
+    /**
      * Hidden references.
      *
      * @var bool
@@ -294,6 +301,7 @@ class Configuration
             'skipTag' => $this->skipTag(),
             'skipVerify' => $this->skipVerify(),
             'disableLinks' => $this->isDisableLinks(),
+            'changelogVersionFormat' => $this->getChangelogVersionFormat(),
             'hiddenHash' => $this->isHiddenHash(),
             'hiddenMentions' => $this->isHiddenMentions(),
             'hiddenReferences' => $this->isHiddenReferences(),
@@ -370,6 +378,8 @@ class Configuration
             ->setIssueUrlFormat($params['issueUrlFormat'])
             ->setUserUrlFormat($params['userUrlFormat'])
             ->setReleaseCommitMessageFormat($params['releaseCommitMessageFormat'])
+            ->setDisableLinks($params['disableLinks'])
+            ->setChangelogVersionFormat($params['changelogVersionFormat'])
             // Hooks
             ->setPreRun($params['preRun'])
             ->setPostRun($params['postRun']);
@@ -689,6 +699,18 @@ class Configuration
     public function setDisableLinks(bool $disableLinks): self
     {
         $this->disableLinks = $disableLinks;
+
+        return $this;
+    }
+
+    public function getChangelogVersionFormat(): string
+    {
+        return $this->changelogVersionFormat;
+    }
+
+    public function setChangelogVersionFormat($changelogVersionFormat): self
+    {
+        $this->changelogVersionFormat = $changelogVersionFormat;
 
         return $this;
     }


### PR DESCRIPTION
Published a PHP plugin to a third party store which requires changelog headings to be in this format: `## X.Y.Z - YYYY-MM-DD`, since I am using this library to generate my changelog I thought it would be very useful to allow you to define your own version format.

By default I kept the format as `## {{version}} ({{date}})` but exposed an extra configuration value which you can set to allow you to change it:

`'changelogVersionFormat' => '## {{version}} - {{date}}',`

Let me know if this requires any further changes.

Thanks