### PR TITLE
feat: allows ability to hide version separator

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -41,6 +41,7 @@ dir or use the `--config` option to specify the location of your configuration f
   Gitlab, Bitbucket, etc)
 - **User Url Format:** A URL representing the a user's profile URL on GitHub, Gitlab, etc. This URL is used for
   substituting @abc with https://github.com/abc in commit messages
+- **Hidden Version Separator:** Hide version separator
 - **Release Commit Message Format:** A string to be used to format the auto-generated release commit message
 - **Pre Run**: Run a callback or command before run the script
 - **Post Run**: Run a callback or command after run the script
@@ -97,6 +98,7 @@ return [
   'issueUrlFormat' => '{{host}}/{{owner}}/{{repository}}/issues/{{id}}',
   'userUrlFormat' => '{{host}}/{{user}}',
   'releaseCommitMessageFormat' => 'chore(release): {{currentTag}}',
+  'hiddenVersionSeparator' => false,
   'preRun' => null,
   'postRun' => null,
 ];

--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -534,7 +534,12 @@ class Changelog
             }
         }
         // Add version separator
-        $changelog .= "\n---\n\n";
+        if (! $this->config->isHiddenVersionSeparator()) {
+            $changelog .= "\n---\n";
+        }
+
+        $changelog .= "\n";
+
 
         return $changelog;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -230,6 +230,13 @@ class Configuration
     protected $prettyScope = true;
 
     /**
+     * Hide Version Separator.
+     *
+     * @var boolean
+     */
+    protected $hiddenVersionSeparator = false;
+
+    /**
      * Sort by options and orientation.
      *
      * @var string[]
@@ -312,6 +319,7 @@ class Configuration
             'compareUrlFormat' => $this->getCompareUrlFormat(),
             'issueUrlFormat' => $this->getIssueUrlFormat(),
             'userUrlFormat' => $this->getUserUrlFormat(),
+            'hiddenVersionSeparator' => $this->isHiddenVersionSeparator(),
             'releaseCommitMessageFormat' => $this->getReleaseCommitMessageFormat(),
             'preRun' => $this->getPreRun(),
             'postRun' => $this->getPostRun(),
@@ -369,6 +377,7 @@ class Configuration
             ->setHiddenHash($params['hiddenHash'])
             ->setHiddenMentions($params['hiddenMentions'])
             ->setHiddenReferences($params['hiddenReferences'])
+            ->setHiddenVersionSeparator($params['hiddenVersionSeparator'])
             // Formats
             ->setPrettyScope($params['prettyScope'])
             ->setUrlProtocol($params['urlProtocol'])
@@ -867,6 +876,18 @@ class Configuration
     public function setPackageLockCommit(bool $packageLockCommit): Configuration
     {
         $this->packageLockCommit = $packageLockCommit;
+
+        return $this;
+    }
+
+    public function isHiddenVersionSeparator(): bool
+    {
+        return $this->hiddenVersionSeparator;
+    }
+
+    public function setHiddenVersionSeparator($hiddenVersionSeparator): Configuration
+    {
+        $this->hiddenVersionSeparator = $hiddenVersionSeparator;
 
         return $this;
     }


### PR DESCRIPTION
Been working with a system that automatically injects version separators into changelogs. This formatting seemed to cause some issues, so I thought it would be beneficial to allow me to turn separators off when generating my own

Thanks

![image](https://user-images.githubusercontent.com/18261676/128409968-c8d4694e-1507-414b-b202-91e28654fc12.png)
