### PR TITLE
fix: version separator markdown

### DIFF
--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -534,12 +534,11 @@ class Changelog
             }
         }
         // Add version separator
-        if (! $this->config->isHiddenVersionSeparator()) {
-            $changelog .= "\n---\n";
+        if (!$this->config->isHiddenVersionSeparator()) {
+            $changelog .= "\n\n---\n";
         }
 
         $changelog .= "\n";
-
 
         return $changelog;
     }


### PR DESCRIPTION
When there are no notable changes, the delimiter does not behave correctly. In markdown syntax, if there are 3 minus signs immediately after the line, then this is the header. For the delimiter, you must use an empty line in front of it.

---

Current behavior (without this commit):
![Screenshot from 2021-09-16 09-24-55](https://user-images.githubusercontent.com/12627650/133560978-8a0124e3-696c-4ece-b2ba-49a406bc09c8.png)

---

With this commit:
![Screenshot from 2021-09-16 09-23-53](https://user-images.githubusercontent.com/12627650/133561097-7ba9fa23-6bdd-440c-b32f-f58616829c48.png)
