### PR TITLE
Allows own package bumpers

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ dir or use the `--config` option to specify the location of your configuration f
 - **Tag Prefix:** Add prefix to release tag
 - **Tag Suffix:** Add suffix to release tag
 - **Skip Bump:** Skip automatic version code bump
+- **Package Bumps:** Array of files to replace version, defaults to `['ConventionalChangelog\PackageBump\ComposerJson', 'ConventionalChangelog\PackageBump\PackageJson']`
 - **Skip Tag:** Skip automatic commit tagging
 - **Skip Verify:** Skip the pre-commit and commit-msg hooks
 - **Disable Links:** Render text instead of link in changelog
@@ -77,6 +78,7 @@ return [
   ],
   'types' => [],
   'packageBump' => true,
+  'packageBumps' => [],
   'packageLockCommit' => true,
   'ignoreTypes' => ['build', 'chore', 'ci', 'docs', 'perf', 'refactor', 'revert', 'style', 'test'],
   'ignorePatterns' => ['/^chore\(release\):/i'],

--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -87,6 +87,11 @@ class Changelog
             PackageJson::class,
         ];
 
+        // Allow config to specify own packages.
+        if ($this->config->getPackageBumps()) {
+          $packageBumps = $this->config->getPackageBumps();
+        }
+
         $this->hasValidRemoteUrl = Repository::hasRemoteUrl() && !empty(Repository::parseRemoteUrl());
 
         // Hook pre run

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -81,6 +81,13 @@ class Configuration
     protected $packageBump = true;
 
     /**
+     * Bump packages.
+     *
+     * @var array
+     */
+    protected $packageBumps = [];
+
+    /**
      * Commit package lock file.
      *
      * @var bool
@@ -299,6 +306,7 @@ class Configuration
             'preset' => $this->getPreset(),
             'types' => [],
             'packageBump' => $this->isPackageBump(),
+            'packageBumps' => [],
             'packageLockCommit' => $this->isPackageLockCommit(),
             'ignoreTypes' => $this->getIgnoreTypes(),
             'ignorePatterns' => $this->getIgnorePatterns(),
@@ -359,6 +367,7 @@ class Configuration
             ->setTypes($params['preset'])
             // Package
             ->setPackageBump($params['packageBump'])
+            ->setPackageBumps($params['packageBumps'])
             ->setPackageLockCommit($params['packageLockCommit'])
             // Document
             ->setHeaderTitle($params['headerTitle'])
@@ -866,6 +875,18 @@ class Configuration
         $this->packageBump = $packageBump;
 
         return $this;
+    }
+
+    public function setPackageBumps(array $packageBumps): Configuration
+    {
+        $this->packageBumps = $packageBumps;
+
+        return $this;
+    }
+
+    public function getPackageBumps(): array
+    {
+        return $this->packageBumps;
     }
 
     public function isPackageLockCommit(): bool


### PR DESCRIPTION
We need this because we might have a package.json file present as well, and only need the version info in composer.json