### PR TITLE
fix(semver): bump minor version when breaking change before 1.0.0

### DIFF
--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -339,15 +339,19 @@ class Changelog
             }
 
             if ($params['autoBump']) {
+                $semver = new SemanticVersion($params['from']);
                 $bumpRelease = SemanticVersion::PATCH;
 
                 if ($summary['breaking_changes'] > 0) {
                     $bumpRelease = SemanticVersion::MAJOR;
+
+                    if (version_compare($semver->getVersion(), '1.0.0', '<')) {
+                        $bumpRelease = SemanticVersion::MINOR;
+                    }
                 } elseif ($summary['feat'] > 0) {
                     $bumpRelease = SemanticVersion::MINOR;
                 }
 
-                $semver = new SemanticVersion($params['from']);
                 $newVersion = $semver->bump($bumpRelease);
                 $params['to'] = $newVersion;
             }


### PR DESCRIPTION
SemVer states that:

> Major version zero (0.y.z) is for initial development. Anything MAY
change at any time. The public API SHOULD NOT be considered stable.

If a breaking changes happens before the first stable version (1.0.0),
it should not force a major version bump, but rather a minor one.