### PR TITLE
fix!: sort git tags by version instead of creation date, match prefix…

### DIFF
--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -139,7 +139,7 @@ class Changelog
         $firstCommit = Repository::getFirstCommit();
 
         if (!$firstRelease) {
-            $lastVersion = Repository::getLastTag(); // Last version
+            $lastVersion = Repository::getLastTag($tagPrefix); // Last version
 
             $bumpRelease = SemanticVersion::PATCH;
 
@@ -174,7 +174,7 @@ class Changelog
 
         if ($history) {
             $changelogCurrent = ''; // Clean changelog file
-            $tags = Repository::getTags();
+            $tags = Repository::getTags($tagPrefix);
 
             $previousTag = null;
             foreach ($tags as $key => $toTag) {

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -54,17 +54,17 @@ class Repository
     /**
      * Get last tag.
      */
-    public static function getLastTag(): string
+    public static function getLastTag($prefix = ''): string
     {
-        return self::run("git for-each-ref refs/tags --sort=-creatordate --format='%(refname:strip=2)' --count=1");
+        return self::run("git for-each-ref 'refs/tags/". $prefix . "*' --sort=-v:refname --format='%(refname:strip=2)' --count=1");
     }
 
     /**
      * Get last tag commit hash.
      */
-    public static function getLastTagCommit(): string
+    public static function getLastTagCommit($prefix = ''): string
     {
-        $lastTag = self::getLastTag();
+        $lastTag = self::getLastTag($prefix);
 
         return self::run("git rev-parse --verify {$lastTag}");
     }
@@ -141,9 +141,9 @@ class Repository
     /**
      * Get tags.
      */
-    public static function getTags(): array
+    public static function getTags($prefix = ''): array
     {
-        $tags = self::run("git tag --sort=-creatordate --list --format='%(refname:strip=2)" . self::$delimiter . "'") . "\n";
+        $tags = self::run("git tag '". $prefix . "*' --sort=-v:refname --list --format='%(refname:strip=2)" . self::$delimiter . "'") . "\n";
         $tagsArray = explode(self::$delimiter . "\n", $tags);
         array_pop($tagsArray);
 


### PR DESCRIPTION
… when listing tags

git tags were sorted by creation date which can lead to wrong versions.
Consider a scenarion where a patch version (e.g. 1.0.1) for an older version (e.g. 1.0.0) is released after a major version has been released (e.g. 2.0.0).
With the current sorting any new tag is created based on 1.0.1, even if it's code is based on 2.0.0.
To further clarify/stabilize the determination of the latest tag, the configured tag prefix (if any) is taken into account when listing tags.

BREAKING CHANGE: Workflows which rely on the chronological order of tags will potentially break. Also workflows with mixed tag prefixes will potentially break.