### PR TITLE
feat: optional tag annotation support

### DIFF
--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -53,6 +53,7 @@ class Changelog
         $autoCommit = $input->getOption('commit'); // Commit once changelog is generated
         $autoCommitAll = $input->getOption('commit-all'); // Commit all changes once changelog is generated
         $autoTag = !($input->getOption('no-tag') || $this->config->skipTag()); // Tag release once is committed
+        $annotateTag = $input->getOption('annotate-tag');
         $amend = $input->getOption('amend'); // Amend commit
         $hooks = !$input->getOption('no-verify'); // Verify git hooks
         $hooks = $hooks && $this->config->skipVerify() ? false : true;
@@ -419,7 +420,7 @@ class Changelog
                 // Create tag
                 if ($autoTag) {
                     $tag = $tagPrefix . $newVersion . $tagSuffix;
-                    $result = Repository::tag($tag);
+                    $result = Repository::tag($tag, $annotateTag);
                     if ($result !== false) {
                         $output->success("Release tagged with success! New version: {$tag}");
                     } else {

--- a/src/DefaultCommand.php
+++ b/src/DefaultCommand.php
@@ -83,6 +83,7 @@ class DefaultCommand extends Command
                 new InputOption('history', null, InputOption::VALUE_NONE, 'Generate the entire history of changes of all releases'),
                 new InputOption('no-verify', null, InputOption::VALUE_NONE, 'Bypasses the pre-commit and commit-msg hooks'),
                 new InputOption('no-tag', null, InputOption::VALUE_NONE, 'Disable release auto tagging'),
+                new InputOption('annotate-tag', null, InputOption::VALUE_OPTIONAL, 'Make an unsigned, annotated tag object once changelog is generated', false),
                 new InputOption('merged', null, InputOption::VALUE_NONE, 'Only include commits whose tips are reachable from HEAD.'),
             ]);
     }

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -57,8 +57,8 @@ class Repository
     public static function getLastTag($merged = false, $prefix = ''): string
     {
         $merged = ($merged) ? '--merged' : '';
-  
-        return self::run("git for-each-ref 'refs/tags/". $prefix . "*' --sort=-v:refname --format='%(refname:strip=2)' --count=1 {$merged}");
+
+        return self::run("git for-each-ref 'refs/tags/" . $prefix . "*' --sort=-v:refname --format='%(refname:strip=2)' --count=1 {$merged}");
     }
 
     /**
@@ -145,7 +145,7 @@ class Repository
      */
     public static function getTags($prefix = ''): array
     {
-        $tags = self::run("git tag '". $prefix . "*' --sort=-v:refname --list --format='%(refname:strip=2)" . self::$delimiter . "'") . "\n";
+        $tags = self::run("git tag '" . $prefix . "*' --sort=-v:refname --list --format='%(refname:strip=2)" . self::$delimiter . "'") . "\n";
         $tagsArray = explode(self::$delimiter . "\n", $tags);
         array_pop($tagsArray);
 
@@ -205,9 +205,12 @@ class Repository
      *
      * @return string
      */
-    public static function tag(string $name)
+    public static function tag(string $name, $annotation = false)
     {
-        return exec("git tag {$name}");
+        $message = $annotation ?: $name;
+        $flags = $annotation !== false ? "-a -m {$message}" : '';
+
+        return exec("git tag {$flags} {$name}");
     }
 
     /**


### PR DESCRIPTION
# Why this PR?

Instead of lightweight tags, I would like to have annotated tags when generating the changelog.

# What changed? 

As annotation flag is optional nothing change for current users of package. Those who would like to have annotated tags may use `--annotate-tag` flag on current release scripts. The new flag uses an optional value, which is a message to be used to annotate the tag. If no value is given, the tag name will be used as an annotation.

### Examples

```
"scripts": [
    "release": "conventional-changelog --commit", # works as before pr
    "release:no-message": "conventional-changelog --annotate-tag --commit", # uses tag name as annotation message 
    "release:with-message": "conventional-changelog --annotate-tag 'custom message' --commit", # uses 'custom message' as annotation message 
]
```