### PR TITLE
feat: add a getCurrentBranch method to Repository

### DIFF
--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -72,6 +72,15 @@ class Repository
     }
 
     /**
+     * Get current branch name.
+     */
+    public static function getCurrentBranch(): string
+    {
+
+        return self::run("git branch --show-current");
+    }
+
+    /**
      * Get commit date.
      */
     public static function getCommitDate($hash): DateTime


### PR DESCRIPTION
Could be usefull to use in config as `'headerDescription' => 'Changelog de SPIP '. Repository::getCurrentBranch(),`