### PR TITLE
fix: extra release generation

### DIFF
--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -153,10 +153,13 @@ class Changelog
                 $bumpRelease = SemanticVersion::PATCH;
             } elseif ($preRelease) {
                 $bumpRelease = SemanticVersion::RC;
+                $autoBump = !$this->config->skipBump();
             } elseif ($betaRelease) {
                 $bumpRelease = SemanticVersion::BETA;
+                $autoBump = !$this->config->skipBump();
             } elseif ($alphaRelease) {
                 $bumpRelease = SemanticVersion::ALPHA;
+                $autoBump = !$this->config->skipBump();
             } else {
                 $autoBump = !$this->config->skipBump();
             }

--- a/src/Git/ConventionalCommit.php
+++ b/src/Git/ConventionalCommit.php
@@ -207,9 +207,16 @@ class ConventionalCommit extends Commit
     protected function parseHeader(string $header)
     {
         preg_match(self::PATTERN_HEADER, $header, $matches);
-        $this->setType((string)$matches['type'])
-            ->setScope((string)$matches['scope'])
-            ->setBreakingChange(!empty($matches['breaking_before'] || !empty($matches['breaking_after'])))
-            ->setDescription((string)$matches['description']);
+
+        $type = $matches['type'] ?? '';
+        $scope = $matches['scope'] ?? '';
+        $breakingBefore = $matches['breaking_before'] ?? '';
+        $breakingAfter = $matches['breaking_after'] ?? '';
+        $description = $matches['description'] ?? '';
+
+        $this->setType($type)
+            ->setScope($scope)
+            ->setBreakingChange(!empty($breakingBefore || !empty($breakingAfter)))
+            ->setDescription($description);
     }
 }

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -54,11 +54,40 @@ class Repository
     /**
      * Get last tag.
      */
-    public static function getLastTag($prefix = '', $merged = false): string
+    public static function getLastTag(): string
     {
-        $merged = $merged ? '--merged' : '';
+        return self::run('git describe --tags --exclude "*-*" --abbrev=0');
+    }
 
-        return self::run('git for-each-ref ' /* 'refs/tags/" . $prefix . "*' */ . " --sort=-v:refname --format='%(refname:strip=2)' --count=1 {$merged}");
+    /**
+     * Get last alpha tag based on a tag pattern.
+     */
+    public static function getLastAlphaTag(string $lastTag = ''): ?string
+    {
+        return self::getTag($lastTag, 'alpha');
+    }
+
+    /**
+     * Get last release candidate tag based on a tag pattern.
+     */
+    public static function getLastReleaseCandidateTag(string $lastTag = ''): ?string
+    {
+        return self::getTag($lastTag, 'rc');
+    }
+
+    /**
+     * Get last beta tag based on a tag pattern.
+     */
+    public static function getLastBetaTag(string $lastTag = ''): ?string
+    {
+        return self::getTag($lastTag, 'beta');
+    }
+
+    private static function getTag(string $tag, string $match): ?string
+    {
+        $find = self::run(sprintf('git describe --tags --match "*%s*-%s*" --abbrev=0', $tag, $match));
+
+        return !empty($find) ? $find : null;
     }
 
     /**


### PR DESCRIPTION
## Description
This PR aims to fix the "extra release" tag generation (=> alpha, beta, rc).

Extra release tag generation is supposed to work as follow:

1. fetch the last `release tag` created
2. check if an `extra release tag` was created for this tag
3. if an `extra release tag` was created, increment it. If not, create it.

## Examples: 

### RC tag creation when one already exists

1. Last release tag: `v1.1.0`
2. Last release candidate tag: `v1.1.1-rc.1`
3. New release candidate tag: `v1.1.1-rc.2`

### RC tag creation when none already exists

1. Last release tag: `v1.1.0`
2. Last release candidate tag: `null`
3. New release candidate tag: `v1.1.1-rc.1`
