### PR TITLE
feat: New option: Do not update CHANGELOG if no commits found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Options:
       --history                      Generate the entire history of changes of all releases
       --no-verify                    Bypasses the pre-commit and commit-msg hooks
       --no-tag                       Disable release auto tagging
+      --no-change-without-commits    Do not apply change if no commits
       --annotate-tag[=ANNOTATE-TAG]  Make an unsigned, annotated tag object once changelog is generated [default: false]
       --merged                       Only include commits whose tips are reachable from HEAD
   -h, --help                         Display help for the given command. When no command is given display help for the changelog command

--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -53,6 +53,7 @@ class Changelog
         $autoCommit = $input->getOption('commit'); // Commit once changelog is generated
         $autoCommitAll = $input->getOption('commit-all'); // Commit all changes once changelog is generated
         $autoTag = !($input->getOption('no-tag') || $this->config->skipTag()); // Tag release once is committed
+        $noChangeWithoutCommits = $input->getOption('no-change-without-commits');
         $annotateTag = $input->getOption('annotate-tag');
         $amend = $input->getOption('amend'); // Amend commit
         $hooks = !$input->getOption('no-verify'); // Verify git hooks
@@ -387,6 +388,12 @@ class Changelog
             $changelogNew .= $this->getMarkdownChanges($changes);
         }
         $filesToCommit = [$file];
+
+        if (isset($commits) && ! count($commits) && $noChangeWithoutCommits) {
+            $output->warning('No commits since last version.');
+
+            return 0; // Command::SUCCESS;
+        }
 
         if ($this->config->isPackageBump()) {
             foreach ($packageBumps as $packageBump) {

--- a/src/DefaultCommand.php
+++ b/src/DefaultCommand.php
@@ -83,6 +83,7 @@ class DefaultCommand extends Command
                 new InputOption('history', null, InputOption::VALUE_NONE, 'Generate the entire history of changes of all releases'),
                 new InputOption('no-verify', null, InputOption::VALUE_NONE, 'Bypasses the pre-commit and commit-msg hooks'),
                 new InputOption('no-tag', null, InputOption::VALUE_NONE, 'Disable release auto tagging'),
+                new InputOption('no-change-without-commits', null, InputOption::VALUE_NONE, 'Do not apply change if no commits'),
                 new InputOption('annotate-tag', null, InputOption::VALUE_OPTIONAL, 'Make an unsigned, annotated tag object once changelog is generated', false),
                 new InputOption('merged', null, InputOption::VALUE_NONE, 'Only include commits whose tips are reachable from HEAD'),
             ]);


### PR DESCRIPTION
Hello,

I suggest you a new option `--no-change-without-commits` who dont update CHANGELOG if no commits found and produce a warning :

![image](https://user-images.githubusercontent.com/6459452/203925116-93a868e1-27f9-4576-a810-ac85debb3f15.png)
