### PR TITLE
fix: Remove negated hyphen from tag-filtering regex to find alpha/beta tags

### DIFF
--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -73,7 +73,7 @@ class Repository
         $tagsArray = explode(self::$delimiter . "\n", $tags);
         $prefixQuote = preg_quote($prefix);
 
-        $tagsFound = preg_grep('/^' . $prefixQuote . '[^-]*$/', $tagsArray);
+        $tagsFound = preg_grep('/^' . $prefixQuote . '.*$/', $tagsArray);
 
         $lastBaseTag = '0.0.0';
         if (count($tagsFound) > 0) {


### PR DESCRIPTION
This fix is to resolve issue #48 

The fixed regex pattern filters out branches which contains `-`, like v1.1.0-alpha.1
Because of this filtering the generated changelog doesn't contains the changes from the previous alpha/beta tag to the current.
