### PR TITLE
fix: Can parse header with carriage return and newline.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/**
 .idea
 .php-cs-fixer.cache
 cghooks.lock
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,11 @@
             "ConventionalChangelog\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "scripts": {
         "changelog": "php conventional-changelog",
         "check-cs": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --diff-format=udiff --config=.php-cs-fixer.php",
@@ -51,7 +56,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
-        "brainmaestro/composer-git-hooks": "^2.8"
+        "brainmaestro/composer-git-hooks": "^2.8",
+        "phpunit/phpunit": "^9.5"
     },
     "require": {
         "php": ">=7.1.3",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -121,17 +121,9 @@ class Changelog
 
         // Get changelogs content
         if (file_exists($file)) {
-            $changelogCurrent = file_get_contents($file);
-            $changelogCurrent = ltrim($changelogCurrent);
-
-            // Remove header
-            $beginHeader = preg_quote($mainHeaderPrefix, '/');
-            $endHeader = preg_quote($mainHeaderSuffix, '/');
-
-            $pattern = '/^(' . $beginHeader . '(.*)' . $endHeader . ')/si';
-            $pattern = preg_replace(['/[\n]+/', '/[\s]+/'], ['[\n]+', '[\s]+'], $pattern);
-
-            $changelogCurrent = preg_replace($pattern, '', $changelogCurrent);
+            $changelogCurrent = $this->extractCurrentChangelogWithoutHeader(
+                file_get_contents($file)
+            );
         }
 
         // Current Dates
@@ -466,6 +458,17 @@ class Changelog
         $this->config->postRun();
 
         return 0; // Command::SUCCESS;
+    }
+
+    protected function extractCurrentChangelogWithoutHeader(string $content): string
+    {
+        $content = ltrim($content);
+
+        return preg_replace(
+            '#<!--- BEGIN HEADER -->.*<!--- END HEADER -->(.*?)#iUs',
+            '\1',
+            $content
+        );
     }
 
     /**

--- a/tests/ChangelogTest.php
+++ b/tests/ChangelogTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests;
+
+use ConventionalChangelog\Changelog;
+use ConventionalChangelog\Configuration;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class ChangelogTest extends TestCase
+{
+    /** @test */
+    public function can_have_current_changelog_without_header()
+    {
+        $configuration = $this->createMock(Configuration::class);
+
+        $changelog = new Changelog($configuration);
+
+        $class = new ReflectionClass($changelog);
+        $method = $class->getMethod('extractCurrentChangelogWithoutHeader');
+        $method->setAccessible(true);
+
+        $content = <<<EOF
+<!--- BEGIN HEADER -->
+# Changelog
+
+All notable changes to this project will be documented in this file.
+<!--- END HEADER -->
+
+## 0.0.1 (1970-01-01)
+
+### Features
+
+* Here we go !
+
+EOF;
+
+        $expectedContent = <<<EOF
+
+
+## 0.0.1 (1970-01-01)
+
+### Features
+
+* Here we go !
+
+EOF;
+
+        $actualContent = $method->invokeArgs(
+            $changelog,
+            [$content]
+        );
+
+        $this->assertEquals($expectedContent, $actualContent);
+    }
+}


### PR DESCRIPTION
Hello,

I have an old repository where I added the package.

When I run the command the headers are repeated because those in place are not detected

I print you the result after the command :

`````markdown
<!--- BEGIN HEADER -->
# Changelog

All notable changes to this project will be documented in this file.
<!--- END HEADER -->

## 4.0.2 (2022-11-25)

### Documentation

* Preparing CHANGELOG for automation.

<!--- BEGIN HEADER -->
# Changelog

All notable changes to this project will be documented in this file.
<!--- END HEADER -->

## 4.0.1 (2022-08-05)
``````

So I made a fix with a test :)

