### PR TITLE
Improve footer refs match

### DIFF
--- a/src/Git/Commit/Footer.php
+++ b/src/Git/Commit/Footer.php
@@ -49,7 +49,7 @@ class Footer implements Stringable
 
         $refs = [];
         $tokenLower = strtolower($this->token);
-        $values = preg_split('/[,\s]/', $this->value);
+        $values = preg_split('/[,\s]+/', $this->value, -1, PREG_SPLIT_NO_EMPTY);
         foreach ($values as $val) {
             if (isset($val[0]) && $val[0] === '#') {
                 $ref = ltrim($val, '#');

--- a/src/Git/Commit/Footer.php
+++ b/src/Git/Commit/Footer.php
@@ -51,7 +51,7 @@ class Footer implements Stringable
         $tokenLower = strtolower($this->token);
         $values = preg_split('/[,\s]/', $this->value);
         foreach ($values as $val) {
-            if ($val[0] === '#') {
+            if (isset($val[0]) && $val[0] === '#') {
                 $ref = ltrim($val, '#');
                 $obj = new Reference($ref);
                 if (in_array($tokenLower, self::TOKEN_CLOSE_ISSUE)) {


### PR DESCRIPTION
Sometimes footer refs are not well formatted, and it triggers an error:

```
Warning: Uninitialized string offset 0 in /var/www/html/vendor/marcocesarato/php-conventional-changelog/src/Git/Commit/Footer.php on line 54
```