### PR TITLE
fix unicode encode error

### DIFF
--- a/src/Type/PackageBump.php
+++ b/src/Type/PackageBump.php
@@ -155,7 +155,7 @@ abstract class PackageBump
         if ($this->exists()) {
             switch ($this->fileType) {
                 case 'json':
-                    $content = json_encode($this->content, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                    $content = json_encode($this->content, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
                     if ($content === null && json_last_error() !== JSON_ERROR_NONE) {
                         throw new \Exception(json_last_error_msg(), json_last_error());
                     }


### PR DESCRIPTION
```diff
---"description": "A PHP package template repository. - \u4e00\u4e2aPHP\u8f6f\u4ef6\u5305\u6a21\u677f\u5b58\u50a8\u5e93\u3002",
+++"description": "A PHP package template repository. - 一个PHP软件包模板存储库。",
```