### PR TITLE
fix: symfony 7 compatibility command

### DIFF
--- a/src/DefaultCommand.php
+++ b/src/DefaultCommand.php
@@ -91,10 +91,8 @@ class DefaultCommand extends Command
 
     /**
      * Execute.
-     *
-     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /**
          * Initialize.


### PR DESCRIPTION
Fix 
```
PHP Fatal error:  Declaration of ConventionalChangelog\DefaultCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int 
```

For symfony 7.

Introduced by my previous PR : https://github.com/marcocesarato/php-conventional-changelog/pull/72