### PR TITLE
fix: Wrong commits with non-latin description grouping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
     "require": {
         "php": ">=7.1.3",
         "ext-json": "*",
-        "symfony/console": "^4 || ^5 || ^6 || ^7"
+        "symfony/console": "^4 || ^5 || ^6 || ^7",
+        "ext-mbstring": "*"
     },
     "extra": {
         "hooks": {

--- a/src/Changelog.php
+++ b/src/Changelog.php
@@ -492,7 +492,7 @@ class Changelog
      */
     protected function getItemKey(string $string): string
     {
-        return strtolower(preg_replace('/[^a-zA-Z0-9_-]+/', '', $string));
+        return mb_strtolower(preg_replace('/\s+/', '', $string));
     }
 
     /**


### PR DESCRIPTION
Original regexp `/[^a-zA-Z0-9_-]+/` removes all cyrillic characters from commit description and unique key becomes empty and, hense, all commit with the same type merge in a single list item in changelog.

Also `strtolower` changed to `mb_strtolower` for correct unicode characters lowercasing.