### PR TITLE
fix: Add void return type to configure() for Symfony Console 7.x compatibility

### DIFF
--- a/conventional-changelog
+++ b/conventional-changelog
@@ -28,6 +28,11 @@ $commandName = $command->getName();
 
 // Run application single command
 $application = new Application('conventional-changelog', '1.17.3');
-$application->add($command);
+// Symfony Console 8.0+ removed add() in favor of addCommand()
+if (method_exists($application, 'addCommand')) {
+    $application->addCommand($command);
+} else {
+    $application->add($command);
+}
 $application->setDefaultCommand($commandName, true);
 $application->run();

--- a/src/DefaultCommand.php
+++ b/src/DefaultCommand.php
@@ -57,7 +57,7 @@ class DefaultCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription("Generate changelogs and release notes from a project's commit messages" .


### PR DESCRIPTION
## Summary

The `configure()` method in `Symfony\Component\Console\Command\Command` now requires a `void` return type declaration in Symfony Console 7.x.

This PR adds the missing return type to fix the fatal error:
```
Declaration of ConventionalChangelog\DefaultCommand::configure() must be compatible with Symfony\Component\Console\Command\Command::configure(): void
```

## Test plan

- [x] Tested locally with PHPUnit 11 (which pulls Symfony Console 7.x)